### PR TITLE
Correction for linux os in uf2 creation and updated libraries

### DIFF
--- a/PlatformIO/create_uf2.py
+++ b/PlatformIO/create_uf2.py
@@ -1,5 +1,6 @@
 import sys
 import struct
+import platform
 
 Import("env")
 
@@ -7,7 +8,8 @@ Import("env")
 def create_uf2(source, target, env):
     # source_hex = target[0].get_abspath()
     source_hex = target[0].get_string(False)
-    source_hex = '.\\'+source_hex
+    if platform.system() == "Windows":
+        source_hex = '.\\'+source_hex
     print("#########################################################")
     print("Create UF2 from "+source_hex)
     print("#########################################################")

--- a/PlatformIO/platformio.ini
+++ b/PlatformIO/platformio.ini
@@ -30,12 +30,12 @@ build_flags =
 	-DFAKE_GPS=0	 ; 1 Enable to get a fake GPS position if no location fix could be obtained
 lib_deps = 
 	beegee-tokyo/WisBlock-API-V2
-	beegee-tokyo/SX126x-Arduino
+	beegee-tokyo/SX126x-Arduino@2.0.24
 	sparkfun/SparkFun u-blox GNSS Arduino Library 
 	mikalhart/TinyGPSPlus
 	adafruit/Adafruit BME680 Library
 	sparkfun/SparkFun LIS3DH Arduino Library
-	sabas1080/CayenneLPP
+	electroniccats/CayenneLPP
 extra_scripts = 
 	pre:rename.py
 	create_uf2.py
@@ -57,11 +57,11 @@ build_flags =
 	-DFAKE_GPS=0	 ; 1 Enable to get a fake GPS position if no location fix could be obtained
 lib_deps = 
 	beegee-tokyo/WisBlock-API-V2
-	beegee-tokyo/SX126x-Arduino
+	beegee-tokyo/SX126x-Arduino@2.0.24
 	sparkfun/SparkFun u-blox GNSS Arduino Library 
 	mikalhart/TinyGPSPlus
 	adafruit/Adafruit BME680 Library
 	sparkfun/SparkFun LIS3DH Arduino Library
-	sabas1080/CayenneLPP
+	electroniccats/CayenneLPP
 extra_scripts = 
 	create_uf2.py


### PR DESCRIPTION
## Updated PlatformIO.ini file

As present in WisBlock-API-V2 commit [1683bf2](https://github.com/beegee-tokyo/WisBlock-API-V2/commit/1683bf25f44205561ff0fbd5525702f3cf638f4c, sabas1080 stopped hosting the CayenneLPP package, transferring it to ElectronicCats [possesion](https://registry.platformio.org/libraries/electroniccats/CayenneLPP), so the platformIO file is updated to change the ownership of this repo.

In the last update of library [SX126x-Arduino](https://github.com/beegee-tokyo/SX126x-Arduino), [beegee-tokyo](https://github.com/beegee-tokyo) with commit [7554799](https://github.com/beegee-tokyo/SX126x-Arduino/commit/7554799489e3e14c0d2b20b4450b53a019ad0869) broke compilation for the library with added code, so the PlatformIO file is updated to use the previous version of the library while the issue isn't fixed.

## UF2 creation for linux

The `create_uf2.py` file has a small issue in the handling source hex path, where an "\" is desnecessarily added in linux, breaking the compilation.

Thx,
Gonçalo